### PR TITLE
fix: Allow jquery noConflict support for ValidatorCallout

### DIFF
--- a/AjaxControlToolkit/Scripts/ValidatorCallout.js
+++ b/AjaxControlToolkit/Scripts/ValidatorCallout.js
@@ -65,8 +65,10 @@ Sys.Extended.UI.ValidatorCalloutBehavior.prototype = {
 
         if(!this._originalValidationMethodOverriden) {
             if(window.jQuery) {
-                $(function() {
-                    self.checkPageValidators(element);
+                window.jQuery(function($) {
+                    $(function() {
+                        self.checkPageValidators(element);
+                    });
                 });
             }
             else


### PR DESCRIPTION
Allow script to operate when jQuery is in noConflict mode (no guarantee access to $ shortcut)