### PR TITLE
HtmlEditorExtender - added a ReadOnly Property. and ForeColorClear button.

### DIFF
--- a/AjaxControlToolkit/HtmlEditorExtender/HtmlEditorExtender.cs
+++ b/AjaxControlToolkit/HtmlEditorExtender/HtmlEditorExtender.cs
@@ -110,6 +110,18 @@ namespace AjaxControlToolkit {
         }
 
         /// <summary>
+        /// Determines if the Html Editor is readOnly.
+        /// </summary>
+        [ExtenderControlProperty]
+        [DefaultValue(false)]
+        [ClientPropertyName("readOnly")]
+        public bool ReadOnly
+        {
+            get { return GetPropertyValue("ReadOnly", false); }
+            set { SetPropertyValue("ReadOnly",value);}
+        }
+
+        /// <summary>
         /// The name of a JavaScript function to attach to the client-side Change event
         /// </summary>
         [ExtenderControlEvent]

--- a/AjaxControlToolkit/HtmlEditorExtender/HtmlEditorExtenderButtons.cs
+++ b/AjaxControlToolkit/HtmlEditorExtender/HtmlEditorExtenderButtons.cs
@@ -617,6 +617,30 @@ namespace AjaxControlToolkit {
         }
     }
 
+
+    public class ForeColorClear : HtmlEditorExtenderButton
+    {
+        public override string CommandName
+        {
+            get { return "ForeColorClear"; }
+        }
+
+        public override string Tooltip
+        {
+            get { return "Fore Color Clear"; }
+        }
+
+        public override Dictionary<string, string[]> ElementWhiteList
+        {
+            get { return null; }
+        }
+
+        public override Dictionary<string, string[]> AttributeWhiteList
+        {
+            get { return null;}
+        }
+    }
+
     public class Indent : HtmlEditorExtenderButton {
         public override string CommandName {
             get { return "Indent"; }

--- a/AjaxControlToolkit/Scripts/HtmlEditorExtender.js
+++ b/AjaxControlToolkit/Scripts/HtmlEditorExtender.js
@@ -30,6 +30,15 @@ Sys.Extended.UI.HtmlEditorExtenderBehavior = function(element) {
     /// <member name="cP:AjaxControlToolkit.HtmlEditorExtender.displaySourceTab" />
     this._displaySourceTab = false;
 
+
+    /// <summary>
+    /// Determines whether The HtmlEditor is readonly
+    /// </summary>
+    /// <getter>get_readOnly</getter>
+    /// <setter>set_readOnly</setter>
+    /// <member name="cP:AjaxControlToolkit.HtmlEditorExtender.readOnly" />
+    this._readOnly = false;
+
     /// <summary>
     /// Button width in pixels
     /// </summary>
@@ -64,7 +73,7 @@ Sys.Extended.UI.HtmlEditorExtenderBehavior = function(element) {
                 overflow: 'auto',
                 clear: 'both'
             },
-            contentEditable: true
+            contentEditable: !this._readOnly
         },
         cssClasses: ['ajax__html_editor_extender_texteditor']
     };
@@ -78,7 +87,7 @@ Sys.Extended.UI.HtmlEditorExtenderBehavior = function(element) {
                 overflow: 'auto',
                 clear: 'both'
             },
-            contentEditable: true
+            contentEditable: !this._readOnly
         },
         cssClasses: ['ajax__html_editor_extender_texteditor']
     };
@@ -583,7 +592,7 @@ Sys.Extended.UI.HtmlEditorExtenderBehavior.prototype = {
                     overflow: 'auto',
                     clear: 'both'
                 },
-                contentEditable: true
+                contentEditable: !this._readOnly
             },
             cssClasses: ['ajax__html_editor_extender_texteditor']
         }, this._container);
@@ -614,7 +623,7 @@ Sys.Extended.UI.HtmlEditorExtenderBehavior.prototype = {
                     overflow: 'auto',
                     clear: 'both'
                 },
-                contentEditable: true
+                contentEditable: !this._readOnly
             },
             cssClasses: ['ajax__html_editor_extender_texteditor']
         }, this._container);
@@ -944,7 +953,16 @@ Sys.Extended.UI.HtmlEditorExtenderBehavior.prototype = {
                 document.execCommand("insertHTML", false, "<hr />");
             else
                 document.execCommand(command.target.name, false, null);
-        } else {
+        }
+        else if (command.target.name === 'ForeColorClear') {
+            if (isIE) {
+                this.setColor('foreColor', '');  //ie8
+            } else {
+                this.setColor('foreColor', 'inherit');  
+            }
+                
+        }
+        else {
             document.execCommand(command.target.name, false, null);
         }
     },
@@ -1232,6 +1250,15 @@ Sys.Extended.UI.HtmlEditorExtenderBehavior.prototype = {
             this.raisePropertyChanged('DisplaySourceTab');
         }
     },
+
+    get_readOnly: function() {
+        return this._readOnly;
+    },
+
+    set_readOnly: function(value) {
+        this._readOnly = value;
+    },
+
 
     /// <summary>
     /// Fires when text change occurs


### PR DESCRIPTION
**HtmlEditorExtender** - added a **ReadOnly** Property. 

**HtmlEditorExtenderButton** - added a **ForeColorClear** button (_Note_: no special icon was setup for this, it's currently set to the first icon no special CSS was added, and would need someone to further edit the sprites to add such an icon.)  ForeColorClear was in the original Control but missing from the Extender.
