### PR TITLE
revert to stable NUnit Console Runner

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,7 @@ os: Visual Studio 2013
 init:
   - git config --global core.autocrlf true
 
+# Workaround for NUnit Console Runner v3.2.1 timeout bug (#1509). Try to remove it when a fix is available.
 install:
 - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/nunit-3-2-0.ps1'))
   

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,9 @@ os: Visual Studio 2013
 init:
   - git config --global core.autocrlf true
 
+install:
+- ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/nunit-3-2-0.ps1'))
+  
 cache:
   - packages -> **\packages.config
 


### PR DESCRIPTION
Workaround for NUnit Console Runner v3.2.1. Try to remove it when a fix is available.

See https://github.com/appveyor/ci/issues/820 for details.
/cc @AlekseyMartynov 