### PR TITLE
Fix FireFox Selenium crash

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,8 +5,9 @@ os: Visual Studio 2013
 init:
   - git config --global core.autocrlf true
 
-# Workaround for NUnit Console Runner v3.2.1 timeout bug (#1509). Try to remove it when a fix is available.
+
 install:
+# Workaround for NUnit Console Runner v3.2.1 timeout bug (#1509). Try to remove it when a fix is available.
 - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/nunit-3-2-0.ps1'))
   
 cache:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,8 @@ init:
 install:
 # Workaround for NUnit Console Runner v3.2.1 timeout bug (#1509). Try to remove it when a fix is available.
 - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/nunit-3-2-0.ps1'))
+# Workaround, as FireFox 47 crashes on Selenium test startup. Wait until stable FireFox is out.
+- choco install firefox -version 46.0.1
   
 cache:
   - packages -> **\packages.config


### PR DESCRIPTION
FireFox 47 crashes instantly when run via Selenium: https://github.com/appveyor/ci/issues/873#issuecomment-228996928