### PR TITLE
CollapsiblePanelExtender - update images even if the target elements have blank src

### DIFF
--- a/AjaxControlToolkit/Scripts/CollapsiblePanel.js
+++ b/AjaxControlToolkit/Scripts/CollapsiblePanel.js
@@ -553,11 +553,11 @@ Sys.Extended.UI.CollapsiblePanelBehavior.prototype = {
                     e.innerHTML = this._collapsedText;
                 }
             }
-            
-            // Change the image if we have one
+
+            // Change the image
             if (this._imageControlID && this._collapsedImage) {
                 var i = $get(this._imageControlID);
-                if (i && i.src) {
+                if (i) {
                     i.src = this._collapsedImage;
                     if (this._expandedText || this._collapsedText) {
                         i.title = this._collapsedText;
@@ -574,10 +574,10 @@ Sys.Extended.UI.CollapsiblePanelBehavior.prototype = {
                 }
             }
             
-            // Change the image if we have one
+            // Change the image
             if (this._imageControlID && this._expandedImage) {
                 var i = $get(this._imageControlID);
-                if (i && i.src) {
+                if (i) {
                     i.src = this._expandedImage;
                     if (this._expandedText || this._collapsedText) {
                             i.title = this._expandedText;

--- a/AjaxControlToolkit/Scripts/CollapsiblePanel.js
+++ b/AjaxControlToolkit/Scripts/CollapsiblePanel.js
@@ -554,10 +554,10 @@ Sys.Extended.UI.CollapsiblePanelBehavior.prototype = {
                 }
             }
 
-            // Change the image
+            // Change the image if we have one
             if (this._imageControlID && this._collapsedImage) {
                 var i = $get(this._imageControlID);
-                if (i) {
+                if (i && i.tagName === "IMG") {
                     i.src = this._collapsedImage;
                     if (this._expandedText || this._collapsedText) {
                         i.title = this._collapsedText;
@@ -574,10 +574,10 @@ Sys.Extended.UI.CollapsiblePanelBehavior.prototype = {
                 }
             }
             
-            // Change the image
+            // Change the image if we have one
             if (this._imageControlID && this._expandedImage) {
                 var i = $get(this._imageControlID);
-                if (i) {
+                if (i && i.tagName === "IMG") {
                     i.src = this._expandedImage;
                     if (this._expandedText || this._collapsedText) {
                             i.title = this._expandedText;


### PR DESCRIPTION
… property declared. If you don't want the target image to be updated just put theses properties to blank inside the CollapsiblePanel (collapsedImage / expandedImage).