### PR TITLE
Fix Calendar tests shifting year issue

### DIFF
--- a/AjaxControlToolkit.Jasmine/Suites/CalendarTests.aspx.cs
+++ b/AjaxControlToolkit.Jasmine/Suites/CalendarTests.aspx.cs
@@ -8,16 +8,16 @@ using System.Web.UI.WebControls;
 namespace AjaxControlToolkit.Jasmine.Suites {
     public partial class CalendarTests : System.Web.UI.Page {
         protected void Page_Load(object sender, EventArgs e) {
-            var selectedDate = new DateTime(2015, 1, 1);
+            var selectedDate = new DateTime(2015, 2, 1);
 
-            StartDateCalendarExtender.StartDate = new DateTime(2015, 1, 1);
+            StartDateCalendarExtender.StartDate = new DateTime(2015, 2, 1);
             StartDateCalendarExtender.SelectedDate = selectedDate;
 
-            EndDateCalendarExtender.EndDate = new DateTime(2015, 1, 1);
+            EndDateCalendarExtender.EndDate = new DateTime(2015, 2, 1);
             EndDateCalendarExtender.SelectedDate = selectedDate;
 
-            BothDatesCalendarExtender.StartDate = new DateTime(2015, 1, 1);
-            BothDatesCalendarExtender.EndDate = new DateTime(2015, 2, 2);
+            BothDatesCalendarExtender.StartDate = new DateTime(2015, 2, 1);
+            BothDatesCalendarExtender.EndDate = new DateTime(2015, 3, 2);
             BothDatesCalendarExtender.SelectedDate = selectedDate;
 
             RangeExceedsDecadeTextBoxCalendarExtender.StartDate = new DateTime(2000, 1, 1);


### PR DESCRIPTION
A calendar date shifts to the previous year when running in environment that has a negative GMT time zone.
An [AppVeyor](https://ci.appveyor.com/) VM instance can run with different regional settings, so this test is green on VM with a non-negative GMT time zone and always red on VM with the negative one.

To fix this, we add a month to the edge date 2015-01-01 to make sure that hours' deviation will not change the initial year of the extender.
