### PR TITLE
Update of the solution and settings for the build with VS2015

### DIFF
--- a/AjaxControlToolkit.sln
+++ b/AjaxControlToolkit.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.40629.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AjaxControlToolkit", "AjaxControlToolkit\AjaxControlToolkit.csproj", "{676B3449-93F7-4102-8DF0-FB51911675D6}"
 	ProjectSection(ProjectDependencies) = postProject

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,7 @@ environment:
 
 cache:
   - packages -> **\packages.config
+  - nuget.exe
 
 services: iis
   

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ environment:
 
 cache:
   - packages -> **\packages.config
-  
+ 
 services: iis
   
 before_build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,9 +6,6 @@ init:
 install:
 # Workaround for NUnit Console Runner v3.2.1 timeout bug (#1509). Try to remove it when a fix is available.
   - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/nunit-3-2-0.ps1'))
-# Workaround for NuGet restore path failure (https://github.com/NuGet/Home/issues/3235)
-  - ps: if(Test-Path 'C:\Tools\NuGet3') { $nugetDir = 'C:\Tools\NuGet3' } else { $nugetDir = 'C:\Tools\NuGet' }
-  - ps: (New-Object Net.WebClient).DownloadFile('https://dist.nuget.org/win-x86-commandline/v3.3.0/nuget.exe', "$nugetDir\NuGet.exe")
 
 environment:
   AjaxControlToolkitTestSiteUrl: http://localhost/TestRunner.aspx
@@ -19,7 +16,7 @@ cache:
 services: iis
   
 before_build:
-  - nuget restore
+  - nuget restore AjaxControlToolkit.sln
 
 build:
   project: AjaxControlToolkit.sln

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ install:
 # Workaround for NUnit Console Runner v3.2.1 timeout bug (#1509). Try to remove it when a fix is available.
   - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/nunit-3-2-0.ps1'))
 # Workaround for NuGet restore path failure (https://github.com/NuGet/Home/issues/3235)
-  - appveyor DownloadFile https://dist.nuget.org/win-x86-commandline/v3.3.0/nuget.exe
+  - ps: if(-Not (Test-Path "nuget.exe")) { Start-FileDownload "https://dist.nuget.org/win-x86-commandline/v3.3.0/nuget.exe" }
 
 environment:
   AjaxControlToolkitTestSiteUrl: http://localhost/TestRunner.aspx

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,8 @@ init:
 install:
 # Workaround for NUnit Console Runner v3.2.1 timeout bug (#1509). Try to remove it when a fix is available.
   - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/nunit-3-2-0.ps1'))
+# Workaround for NuGet restore path failure (https://github.com/NuGet/Home/issues/3235)
+  - appveyor DownloadFile https://dist.nuget.org/win-x86-commandline/v3.3.0/nuget.exe
 
 environment:
   AjaxControlToolkitTestSiteUrl: http://localhost/TestRunner.aspx

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,20 +1,21 @@
 version: '{build}'
 
-os: Visual Studio 2013
-
 init:
   - git config --global core.autocrlf true
 
 install:
 # Workaround for NUnit Console Runner v3.2.1 timeout bug (#1509). Try to remove it when a fix is available.
   - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/nunit-3-2-0.ps1'))
+# Workaround for NuGet MSBuild auto-detection bug (#1392)
+  - ps: if(Test-Path 'C:\Tools\NuGet3') { $nugetDir = 'C:\Tools\NuGet3' } else { $nugetDir = 'C:\Tools\NuGet' }
+  - ps: (New-Object Net.WebClient).DownloadFile('https://dist.nuget.org/win-x86-commandline/v3.3.0/nuget.exe', "$nugetDir\NuGet.exe")
 
 environment:
   AjaxControlToolkitTestSiteUrl: http://localhost/TestRunner.aspx
 
 cache:
-  - packages -> **\packages.config
-
+  - '%LocalAppData%\NuGet\Cache -> **\packages.config'
+  
 services: iis
   
 before_build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ install:
 # Workaround for NUnit Console Runner v3.2.1 timeout bug (#1509). Try to remove it when a fix is available.
   - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/nunit-3-2-0.ps1'))
 # Workaround for NuGet restore path failure (https://github.com/NuGet/Home/issues/3235)
-  - ps: if(-Not (Test-Path "nuget.exe")) { Start-FileDownload "https://dist.nuget.org/win-x86-commandline/v3.3.0/nuget.exe" }
+  - if not exist "nuget.exe" (appveyor DownloadFile https://dist.nuget.org/win-x86-commandline/v3.3.0/nuget.exe)
 
 environment:
   AjaxControlToolkitTestSiteUrl: http://localhost/TestRunner.aspx

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ environment:
 
 cache:
   - packages -> **\packages.config
- 
+
 services: iis
   
 before_build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ init:
 install:
 # Workaround for NUnit Console Runner v3.2.1 timeout bug (#1509). Try to remove it when a fix is available.
   - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/nunit-3-2-0.ps1'))
-# Workaround for NuGet MSBuild auto-detection bug (#1392)
+# Workaround for NuGet restore path failure (https://github.com/NuGet/Home/issues/3235)
   - ps: if(Test-Path 'C:\Tools\NuGet3') { $nugetDir = 'C:\Tools\NuGet3' } else { $nugetDir = 'C:\Tools\NuGet' }
   - ps: (New-Object Net.WebClient).DownloadFile('https://dist.nuget.org/win-x86-commandline/v3.3.0/nuget.exe', "$nugetDir\NuGet.exe")
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ environment:
   AjaxControlToolkitTestSiteUrl: http://localhost/TestRunner.aspx
 
 cache:
-  - '%LocalAppData%\NuGet\Cache -> **\packages.config'
+  - packages -> **\packages.config
   
 services: iis
   

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ cache:
 services: iis
   
 before_build:
-  - nuget restore AjaxControlToolkit.sln
+  - nuget restore
 
 build:
   project: AjaxControlToolkit.sln


### PR DESCRIPTION
Based on #74.
* The VS 2013 image has been removed; the VS 2015 one is used by default.
* The solution has been upgraded to VS 2015 to [pick up MSBuild 14.0](http://help.appveyor.com/discussions/suggestions/772-use-msbuild-14-by-default).
*  NuGet workaround has been applied to avoid build failure:  https://github.com/NuGet/Home/issues/3235