### PR TITLE
AppVeyor NUnit workaround has been removed

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,8 +4,6 @@ init:
   - git config --global core.autocrlf true
 
 install:
-# Workaround for NUnit Console Runner v3.2.1 timeout bug (#1509). Try to remove it when a fix is available.
-  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/nunit-3-2-0.ps1'))
 # Workaround for NuGet restore path failure (https://github.com/NuGet/Home/issues/3235)
   - if not exist "nuget.exe" (appveyor DownloadFile https://dist.nuget.org/win-x86-commandline/v3.3.0/nuget.exe)
 


### PR DESCRIPTION
[The latest AppVeyor NUnit update](https://www.appveyor.com/updates/2016/11/23/) makes [a workaround for NUnit Console Runner](https://github.com/DevExpress/AjaxControlToolkit/blob/master/appveyor.yml#L7-L8) useless, so I decided to remove it. 