### PR TITLE
Fix Accordion container ID (Resolve #360)

### DIFF
--- a/AjaxControlToolkit/Accordion/Accordion.cs
+++ b/AjaxControlToolkit/Accordion/Accordion.cs
@@ -661,6 +661,7 @@ namespace AjaxControlToolkit {
             var itemArgs = new AccordionItemEventArgs(container, itemType);
             OnItemCreated(itemArgs);
 
+            container.ID = (itemType == AccordionItemType.Header ? "h" : "c") + index;
             container.SetDataItemProperties(dataItem, index, itemType);
             template.InstantiateIn(container);
 


### PR DESCRIPTION
@delta1186 We consider applying this fix instead of adding the `INamingContainer` interface to the `AccordionPane`.
There is no breaking change, because client IDs are not altered, while the `ItemCommand` event is successfully fired.