### PR TITLE
Remove FireFox tests

### DIFF
--- a/AjaxControlToolkit.Tests/JasmineTests.cs
+++ b/AjaxControlToolkit.Tests/JasmineTests.cs
@@ -40,17 +40,6 @@ namespace AjaxControlToolkit.Tests {
         }
 
         [Test]
-        public void FireFox() {
-            var driverService = FirefoxDriverService.CreateDefaultService(_driverDir, "geckodriver.exe");
-            driverService.FirefoxBinaryPath = @"C:\Program Files (x86)\Mozilla Firefox\firefox.exe";
-            driverService.HideCommandPromptWindow = true;
-            driverService.SuppressInitialDiagnosticInformation = true;
-            var driver = new FirefoxDriver(driverService, new FirefoxOptions(), TimeSpan.FromSeconds(60));
-
-            TestBrowser(driver);
-        }
-
-        [Test]
         public void InternetExplorer() {
             var driver = new InternetExplorerDriver(_driverDir, new InternetExplorerOptions(), TimeSpan.FromMinutes(3));
 


### PR DESCRIPTION
Selenium IDE is not compatible with Firefox 55: https://github.com/SeleniumHQ/selenium/issues/4406
Thus, FireFox tests were removed to avoid broken builds.