### PR TITLE
Add switch to read stream via InputStream in AjaxFileUpload

### DIFF
--- a/AjaxControlToolkit.Tests/AjaxFileUploadTests.cs
+++ b/AjaxControlToolkit.Tests/AjaxFileUploadTests.cs
@@ -60,5 +60,15 @@ namespace AjaxControlToolkit.Tests {
             var root = AjaxFileUpload.GetRootTempFolder();
             Assert.Throws<Exception>(() => AjaxFileUpload.CheckTempFilePath(Path.Combine(root, @"extraFolder\E63F2078-D5C7-66FA-5CAD-02C169149BD5\a.tmp")));
         }
+
+        [Test]
+        public void HandleClassicReadEntityBodyMode() {
+            var request = new WorkerRequest("------WebKitFormBoundaryCqenIHPHe1ZTCr0d\r\nContent-Disposition: form-data; name=\"act-file-data\"; filename=\"zero.jpg\"\r\nContent-Type: image/jpeg\r\n\r\n\r\n------WebKitFormBoundaryCqenIHPHe1ZTCr0d--\r\n", "filename=aaa.jpg&fileId=E63F2078-D5C7-66FA-5CAD-02C169149BD5", "multipart/form-data; boundary=----WebKitFormBoundaryCqenIHPHe1ZTCr0d");
+            var context = new HttpContext(request);
+            // read entity via InputStream
+            // https://referencesource.microsoft.com/#System.Web/HttpRequest.cs,3231
+            var a = context.Request.InputStream.Length;
+            AjaxFileUploadHelper.Process(context);
+        }
     }
 }

--- a/AjaxControlToolkit/AjaxControlToolkitConfigSection.cs
+++ b/AjaxControlToolkit/AjaxControlToolkitConfigSection.cs
@@ -37,6 +37,12 @@ namespace AjaxControlToolkit {
             set { base["additionalUploadFileExtensions"] = value; }
         }
 
+        [ConfigurationProperty("useBufferlessInputStream", DefaultValue = true, IsRequired = false)]
+        public bool UseBufferlessInputStream {
+            get { return (bool)base["useBufferlessInputStream"]; }
+            set { base["useBufferlessInputStream"] = value; }
+        }
+
         [ConfigurationProperty("customControls", IsDefaultCollection = false)]
         [ConfigurationCollection(typeof(CustomControlsCollection))]
         public CustomControlsCollection CustomControls {

--- a/AjaxControlToolkit/AjaxFileUpload/AjaxFileUploadHelper.cs
+++ b/AjaxControlToolkit/AjaxFileUpload/AjaxFileUploadHelper.cs
@@ -44,24 +44,6 @@ namespace AjaxControlToolkit {
             "zip"
         };
 
-        /// <summary>
-        /// Specifies to use advanced HttpRequest.GetBufferlessInputStream() method or classic HttpRequest.InputStream property
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// In enviroments where HttpRequest.GetBufferlessInputStream() method throws exception (when entity body has already been loaded and parsed), classic HttpRequest.InputStream property can be used
-        /// </para>
-        /// <para>
-        /// This property might be obsolete after upgrade .NET 4.5 and higher (this behavior can be tested by HttpRequest.ReadEntityBodyMode)
-        /// </para>
-        /// </remarks>
-        public static bool UseBufferlessInputStream { get; set; }
-
-        static AjaxFileUploadHelper()
-        {
-            UseBufferlessInputStream = true;
-        }
-
         public static void Abort(HttpContext context, string fileId) {
             (new AjaxFileUploadStates(context, fileId)).Abort = true;
         }
@@ -80,7 +62,7 @@ namespace AjaxControlToolkit {
             var firstChunk = bool.Parse(request.QueryString["firstChunk"] ?? "false");
             var usePoll = bool.Parse(request.QueryString["usePoll"] ?? "false");
 
-            using(var stream = UseBufferlessInputStream ? request.GetBufferlessInputStream() : request.InputStream) {
+            using(var stream = ToolkitConfig.UseBufferlessInputStream ? request.GetBufferlessInputStream() : request.InputStream) {
                 var success = false;
                 success = ProcessStream(
                     context, stream, fileId, fileName,

--- a/AjaxControlToolkit/AjaxFileUpload/AjaxFileUploadHelper.cs
+++ b/AjaxControlToolkit/AjaxFileUpload/AjaxFileUploadHelper.cs
@@ -44,6 +44,24 @@ namespace AjaxControlToolkit {
             "zip"
         };
 
+        /// <summary>
+        /// Specifies to use advanced HttpRequest.GetBufferlessInputStream() method or classic HttpRequest.InputStream property
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// In enviroments where HttpRequest.GetBufferlessInputStream() method throws exception (when entity body has already been loaded and parsed), classic HttpRequest.InputStream property can be used
+        /// </para>
+        /// <para>
+        /// This property might be obsolete after upgrade .NET 4.5 and higher (this behavior can be tested by HttpRequest.ReadEntityBodyMode)
+        /// </para>
+        /// </remarks>
+        public static bool UseBufferlessInputStream { get; set; }
+
+        static AjaxFileUploadHelper()
+        {
+            UseBufferlessInputStream = true;
+        }
+
         public static void Abort(HttpContext context, string fileId) {
             (new AjaxFileUploadStates(context, fileId)).Abort = true;
         }
@@ -62,7 +80,7 @@ namespace AjaxControlToolkit {
             var firstChunk = bool.Parse(request.QueryString["firstChunk"] ?? "false");
             var usePoll = bool.Parse(request.QueryString["usePoll"] ?? "false");
 
-            using(var stream = request.GetBufferlessInputStream()) {
+            using(var stream = UseBufferlessInputStream ? request.GetBufferlessInputStream() : request.InputStream) {
                 var success = false;
                 success = ProcessStream(
                     context, stream, fileId, fileName,

--- a/AjaxControlToolkit/ToolkitConfig.cs
+++ b/AjaxControlToolkit/ToolkitConfig.cs
@@ -43,6 +43,13 @@ namespace AjaxControlToolkit {
             get { return ConfigSection.AdditionalUploadFileExtensions; }
         }
 
+        public static bool UseBufferlessInputStream {
+            get { return ConfigSection.UseBufferlessInputStream; }
+#if DEBUG
+            set { ConfigSection.UseBufferlessInputStream = value; }
+#endif
+        }
+
         public static IEnumerable<Type> CustomControls {
             get {
                 foreach(var control in ConfigSection.CustomControls)


### PR DESCRIPTION
[The behavior of `Request.GetBufferlessInputStream()` is changed in .NET 4.5](https://blogs.msdn.microsoft.com/praburaj/2012/09/13/httpcontext-current-request-inputstream-property-throws-exception-this-method-or-property-is-not-supported-after-httprequest-getbufferlessinputstream-has-been-invoked-or-httpcontext-cur/).
To make AjaxFileUpload work as before, a new `useBufferlessInputStream` setting has been added.