### PR TITLE
AjaxFileUpload: detect stream read mode dynamically

### DIFF
--- a/AjaxControlToolkit.Tests/AjaxFileUploadTests.cs
+++ b/AjaxControlToolkit.Tests/AjaxFileUploadTests.cs
@@ -61,26 +61,21 @@ namespace AjaxControlToolkit.Tests {
             Assert.Throws<Exception>(() => AjaxFileUpload.CheckTempFilePath(Path.Combine(root, @"extraFolder\E63F2078-D5C7-66FA-5CAD-02C169149BD5\a.tmp")));
         }
 
-#if DEBUG
         [Test]
         public void DoNotUseBufferlessInputStream() {
             var request = new WorkerRequest("------WebKitFormBoundaryCqenIHPHe1ZTCr0d\r\nContent-Disposition: form-data; name=\"act-file-data\"; filename=\"zero.jpg\"\r\nContent-Type: image/jpeg\r\n\r\n\r\n------WebKitFormBoundaryCqenIHPHe1ZTCr0d--\r\n", "filename=aaa.jpg&fileId=E63F2078-D5C7-66FA-5CAD-02C169149BD5", "multipart/form-data; boundary=----WebKitFormBoundaryCqenIHPHe1ZTCr0d");
             var context = new HttpContext(request);
-
-            lock (typeof(AjaxControlToolkitConfigSection)) {
-                var useBufferlessInputStreamOldValue = ToolkitConfig.UseBufferlessInputStream;
-                try {
-                    ToolkitConfig.UseBufferlessInputStream = false;
-                    // read entity via InputStream
-                    // https://referencesource.microsoft.com/#System.Web/HttpRequest.cs,3231
-                    context.Request.InputStream.ReadByte();
-                    Assert.DoesNotThrow(() => AjaxFileUploadHelper.Process(context)); 
-                }
-                finally {
-                    ToolkitConfig.UseBufferlessInputStream = useBufferlessInputStreamOldValue;
-                }
-            }
+            // read entity via InputStream
+            // https://referencesource.microsoft.com/#System.Web/HttpRequest.cs,3231
+            context.Request.InputStream.ReadByte();
+            Assert.DoesNotThrow(() => AjaxFileUploadHelper.Process(context));
         }
-#endif
+
+        [Test]
+        public void UseBufferlessInputStream() {
+            var request = new WorkerRequest("------WebKitFormBoundaryCqenIHPHe1ZTCr0d\r\nContent-Disposition: form-data; name=\"act-file-data\"; filename=\"zero.jpg\"\r\nContent-Type: image/jpeg\r\n\r\n\r\n------WebKitFormBoundaryCqenIHPHe1ZTCr0d--\r\n", "filename=aaa.jpg&fileId=E63F2078-D5C7-66FA-5CAD-02C169149BD5", "multipart/form-data; boundary=----WebKitFormBoundaryCqenIHPHe1ZTCr0d");
+            var context = new HttpContext(request);
+            Assert.DoesNotThrow(() => AjaxFileUploadHelper.Process(context));
+        }
     }
 }

--- a/AjaxControlToolkit.Tests/AjaxFileUploadTests.cs
+++ b/AjaxControlToolkit.Tests/AjaxFileUploadTests.cs
@@ -73,7 +73,6 @@ namespace AjaxControlToolkit.Tests {
             Assert.DoesNotThrow(() => AjaxFileUploadHelper.Process(context));
         }
 
-
         [Test]
         public void DoNotUseBufferlessInputStream() {
             var request = new WorkerRequest(testBody, testQuery, testContentType);

--- a/AjaxControlToolkit/AjaxControlToolkit.csproj
+++ b/AjaxControlToolkit/AjaxControlToolkit.csproj
@@ -36,6 +36,7 @@
     <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
     <Reference Include="System.configuration" />
     <Reference Include="System.Core" />

--- a/AjaxControlToolkit/AjaxFileUpload/AjaxFileUploadHelper.cs
+++ b/AjaxControlToolkit/AjaxFileUpload/AjaxFileUploadHelper.cs
@@ -1,6 +1,5 @@
 using Microsoft.CSharp.RuntimeBinder;
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;

--- a/AjaxControlToolkit/AjaxFileUpload/AjaxFileUploadHelper.cs
+++ b/AjaxControlToolkit/AjaxFileUpload/AjaxFileUploadHelper.cs
@@ -1,4 +1,3 @@
-using Microsoft.CSharp.RuntimeBinder;
 using System;
 using System.IO;
 using System.Linq;
@@ -80,7 +79,7 @@ namespace AjaxControlToolkit {
             try {
                 return Convert.ToInt32((request as dynamic).ReadEntityBodyMode);
             }
-            catch{
+            catch {
                 return 0;
             }
         }

--- a/AjaxControlToolkit/AjaxFileUpload/AjaxFileUploadHelper.cs
+++ b/AjaxControlToolkit/AjaxFileUpload/AjaxFileUploadHelper.cs
@@ -63,14 +63,14 @@ namespace AjaxControlToolkit {
             var firstChunk = bool.Parse(request.QueryString["firstChunk"] ?? "false");
             var usePoll = bool.Parse(request.QueryString["usePoll"] ?? "false");
 
-            using (var stream = GetReadEntityBodyMode(request) != 1 ? request.GetBufferlessInputStream() : request.InputStream) {
+            using(var stream = GetReadEntityBodyMode(request) != 1 ? request.GetBufferlessInputStream() : request.InputStream) {
                 var success = false;
 
                 success = ProcessStream(
                     context, stream, fileId, fileName,
                     chunked, firstChunk, usePoll);
 
-                if (!success)
+                if(!success)
                     request.Form.Clear();
 
                 return success;

--- a/AjaxControlToolkit/AjaxFileUpload/AjaxFileUploadHelper.cs
+++ b/AjaxControlToolkit/AjaxFileUpload/AjaxFileUploadHelper.cs
@@ -65,7 +65,6 @@ namespace AjaxControlToolkit {
 
             using(var stream = GetReadEntityBodyMode(request) != 1 ? request.GetBufferlessInputStream() : request.InputStream) {
                 var success = false;
-
                 success = ProcessStream(
                     context, stream, fileId, fileName,
                     chunked, firstChunk, usePoll);

--- a/AjaxControlToolkit/ToolkitConfig.cs
+++ b/AjaxControlToolkit/ToolkitConfig.cs
@@ -43,13 +43,6 @@ namespace AjaxControlToolkit {
             get { return ConfigSection.AdditionalUploadFileExtensions; }
         }
 
-        public static bool UseBufferlessInputStream {
-            get { return ConfigSection.UseBufferlessInputStream; }
-#if DEBUG
-            set { ConfigSection.UseBufferlessInputStream = value; }
-#endif
-        }
-
         public static IEnumerable<Type> CustomControls {
             get {
                 foreach(var control in ConfigSection.CustomControls)


### PR DESCRIPTION
Based on PR #428 feedback, we reverted its changes and detect the method for reading a stream dynamically instead of using a global config value.