### PR TITLE
Add null-conditional against missing HttpContext

### DIFF
--- a/AjaxControlToolkit/Localization.cs
+++ b/AjaxControlToolkit/Localization.cs
@@ -112,7 +112,7 @@ namespace AjaxControlToolkit {
         }
 
         public virtual bool IsLocalizationEnabled() {
-            var page = HttpContext.Current.Handler as Page;
+            var page = HttpContext.Current?.Handler as Page;
             if(page == null)
                 return true;
 


### PR DESCRIPTION
Fix #486

---

Code to reproduce and check:

Temp.aspx
```xml
<%@ Page Language="C#" AutoEventWireup="true" %>
<!DOCTYPE html>
<html xmlns="http://www.w3.org/1999/xhtml">
<head runat="server"><title></title></head>
<body>
    <form id="form1" runat="server">
        <asp:ScriptManager runat="server"></asp:ScriptManager>
    </form>
</body>
</html>
<script runat="server">
    protected void Page_Load(object sender, EventArgs e) {
        Page.RegisterAsyncTask(new PageAsyncTask(OnBegin, OnEnd, OnTimeOut, null));
    }

    IAsyncResult OnBegin(Object sender, EventArgs e, AsyncCallback cb, object state) {
        return new Action(() => form1.Controls.Add(Page.LoadControl("~/Temp.ascx"))).BeginInvoke(cb, state);
    }

    void OnEnd(IAsyncResult asyncResult) {
    }

    void OnTimeOut(IAsyncResult asyncResult) {
    }
</script>
```

Temp.ascx
```xml
<%@ Control Language="C#" AutoEventWireup="true" %>
<asp:Repeater runat="server" DataSource="<%# new[] { 1 } %>" ID="rep1">
    <ItemTemplate>
        <asp:TextBox ID="Slider1" runat="server" AutoPostBack="true" Text="0" />
        <ajaxToolkit:SliderExtender runat="server" BehaviorID="Slider1" TargetControlID="Slider1" />
        <%# Container.DataItem %>
    </ItemTemplate>
</asp:Repeater>
<script runat="server">
    protected void Page_Load(object sender, EventArgs e) {
        rep1.DataBind();
    }
</script>
```