### PR TITLE
Fix SCRIPT1028 error in legacy IE

### DIFF
--- a/AjaxControlToolkit/Scripts/Common.js
+++ b/AjaxControlToolkit/Scripts/Common.js
@@ -1030,7 +1030,7 @@ Sys.Extended.UI._CommonToolkitScripts.prototype = {
             return true;
 
         return false;
-    },
+    }
 }
 
 // Create the singleton instance of the CommonToolkitScripts


### PR DESCRIPTION
AjaxControlToolkit v19.1.0 breaks in legacy Internet Explorer because of trailing comma (3ce9d94975cd6f5baff57a07f906d93c9c0562f2).

### How to repro
1. Create a web application using an ASP.NET Web Forms template.
1. Install AjaxControlToolkit v19.1.0 from NuGet.
1. Replace the contents of the Default.aspx with following.
```html
<%@ Page Language="C#" AutoEventWireup="true" %>

<%@ Register Assembly="AjaxControlToolkit" Namespace="AjaxControlToolkit" TagPrefix="asp" %>

<!DOCTYPE html>
<html xmlns="http://www.w3.org/1999/xhtml">
<head runat="server">
    <title>Sample</title>
</head>
<body>
    <form id="form1" runat="server">
        <div>
            <asp:ScriptManager ID="ToolkitScriptManager1" runat="server" />
            <asp:ComboBox ID="ComboBox1" runat="server" DropDownStyle="DropDown" AutoCompleteMode="None" CaseSensitive="false" RenderMode="Block" AppendDataBoundItems="true" AutoPostBack="True">
                <asp:ListItem Text="Red"></asp:ListItem>
                <asp:ListItem Text="Green"></asp:ListItem>
                <asp:ListItem Text="Blue"></asp:ListItem>
            </asp:ComboBox>
        </div>
    </form>
</body>
</html>
```
![image](https://user-images.githubusercontent.com/17608272/71087529-c123e480-21df-11ea-8386-bed57656cdba.png)
