### PR TITLE
Fixed issue #553

### DIFF
--- a/AjaxControlToolkit/Scripts/Popup.js
+++ b/AjaxControlToolkit/Scripts/Popup.js
@@ -69,10 +69,6 @@ Sys.Extended.UI.PopupBehavior.prototype = {
     },
 
     show: function() {
-        // Ignore requests to hide multiple times
-        if(this._visible)
-            return;
-
         var eventArgs = new Sys.CancelEventArgs();
         this.raise_showing(eventArgs);
 


### PR DESCRIPTION
If popup was shown it never redrew, causing AutoComplete to shrink in wrong direction when shown above the field.